### PR TITLE
ALVSREP-41 ALVSTDM-30 adds hostname to http client as a demo that /di…

### DIFF
--- a/TdmPrototypeBackend.Azure/AzureService.cs
+++ b/TdmPrototypeBackend.Azure/AzureService.cs
@@ -35,7 +35,10 @@ public abstract class AzureService<T>
 
         if (clientFactory != null)
         {
-            Transport = new HttpClientTransport(clientFactory.CreateClient("proxy"));    
+            var client = clientFactory.CreateClient("proxy");
+            client.DefaultRequestHeaders.Add("Host", "devdmpinfdl1001.blob.core.windows.net");
+            var transport = new HttpClientTransport(client);
+            Transport = transport;
         }
         
     }

--- a/TdmPrototypeDmpSynchroniser.Api/Services/BlobService.cs
+++ b/TdmPrototypeDmpSynchroniser.Api/Services/BlobService.cs
@@ -23,7 +23,7 @@ public class BlobService(ILoggerFactory loggerFactory, SynchroniserConfig config
             {
                 IsLoggingContentEnabled = true,
                 IsLoggingEnabled = true
-            }
+            },
         };
         
         var blobServiceClient = new BlobServiceClient(
@@ -32,7 +32,8 @@ public class BlobService(ILoggerFactory loggerFactory, SynchroniserConfig config
             options);
 
         var containerClient = blobServiceClient.GetBlobContainerClient(config.DmpBlobContainer);
-        
+        // containerClient.
+            
         return containerClient;
     }
 


### PR DESCRIPTION
A POC of how we could modify the host header to match the SSL cert for the private blob storage connection:

devdmpinfdl1001.blob.core.windows.net 10.205.131.199

We currently have an endpoint https://tdm-prototype-backend.localtest.me:3080/diagnostics/blob-internal that uses the env setting DMP_BLOB_PRIVATE_ENDPOINT=10.205.131.199 to test connectivity to a private blob store.

Would need to be refactored before being used for real...

NB, the internal IP is not accessible externally / over the VPN, so i've used a CDP_HTTPS_PROXY env var to use the proxy from CDP.

